### PR TITLE
Allow `filePath` to be changed at runtime

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,58 +3,54 @@ var path = require('path')
 var mkdirp = require('mkdirp')
 var applicationConfigPath = require('application-config-path')
 
-function applicationConfig (name) {
-  var directoryPath = applicationConfigPath(name)
-  var filePath = path.join(directoryPath, 'config.json')
-
-  function read (cb) {
-    fs.readFile(filePath, function (err, raw) {
-      if (err && err.code === 'ENOENT') return cb(null, {})
-      if (err) return cb(err)
-
-      var data
-      try {
-        data = JSON.parse(raw.toString())
-      } catch (err) {
-        return cb(err)
-      }
-
-      cb(null, data)
-    })
-  }
-
-  function trash (cb) {
-    fs.unlink(filePath, function (err) {
-      if (err && err.code !== 'ENOENT') return cb(err)
-
-      fs.rmdir(directoryPath, function (err) {
-        if (err && err.code !== 'ENOENT') return cb(err)
-
-        cb(null)
-      })
-    })
-  }
-
-  function write (data, cb) {
-    mkdirp(directoryPath, function (err) {
-      if (err) { return cb(err) }
-
-      fs.writeFile(filePath, JSON.stringify(data), cb)
-    })
-  }
-
-  return {
-    filePath: filePath,
-    read: read,
-    trash: trash,
-    write: function (data, cb) {
-      if (typeof data !== 'object' || data === null) {
-        throw new TypeError('data is not an object')
-      }
-
-      return write(data, cb)
-    }
-  }
+function ApplicationConfig (name) {
+  this.filePath = path.join(applicationConfigPath(name), 'config.json')
 }
 
-module.exports = applicationConfig
+ApplicationConfig.prototype.read = function (cb) {
+  var self = this
+  fs.readFile(self.filePath, function (err, raw) {
+    if (err && err.code === 'ENOENT') return cb(null, {})
+    if (err) return cb(err)
+
+    var data
+    try {
+      data = JSON.parse(raw.toString())
+    } catch (err) {
+      return cb(err)
+    }
+
+    cb(null, data)
+  })
+}
+
+ApplicationConfig.prototype.write = function (data, cb) {
+  var self = this
+  if (typeof data !== 'object' || data === null) {
+    throw new TypeError('data is not an object')
+  }
+  var directoryPath = path.dirname(self.filePath)
+  mkdirp(directoryPath, function (err) {
+    if (err) { return cb(err) }
+
+    fs.writeFile(self.filePath, JSON.stringify(data), cb)
+  })
+}
+
+ApplicationConfig.prototype.trash = function (cb) {
+  var self = this
+  fs.unlink(self.filePath, function (err) {
+    if (err && err.code !== 'ENOENT') return cb(err)
+
+    var directoryPath = path.dirname(self.filePath)
+    fs.rmdir(directoryPath, function (err) {
+      if (err && err.code !== 'ENOENT') return cb(err)
+
+      cb(null)
+    })
+  })
+}
+
+module.exports = function createApplicationConfig (name) {
+  return new ApplicationConfig(name)
+}


### PR DESCRIPTION
This looks like a huge change, but it doesn't change any behavior. It just allows `filePath` to be changed at runtime and actually have an effect.

`filePath` is already exposed on the returned object, so this just makes changing it actually have an effect on the `read`, `trash`, and `write` functions.

This might seem silly at first, given that the whole point of this package is to put files where the OS wants you to. But, I'm trying to make a Windows [portable app](http://portableapps.com/about/what_is_a_portable_app) for WebTorrent Desktop, i.e. an app that stores all config in the same folder as the app itself. So I need to be able to set the location. I _could_ duplicate the read/write/trash functionality, but this is nicer.
