### PR TITLE
Don't require mkdirp until write() is called

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var fs = require('fs')
 var path = require('path')
-var mkdirp = require('mkdirp')
 var applicationConfigPath = require('application-config-path')
 
 function ApplicationConfig (name) {
@@ -26,6 +25,7 @@ ApplicationConfig.prototype.read = function (cb) {
 
 ApplicationConfig.prototype.write = function (data, cb) {
   var self = this
+  var mkdirp = require('mkdirp')
   if (typeof data !== 'object' || data === null) {
     throw new TypeError('data is not an object')
   }


### PR DESCRIPTION
In WebTorrent Desktop, we load our config at startup, so
application-config is in our critical path.

We're trying to reduce as many require() calls as possible at startup,
so defering this require('mkdirp') until it's actually needed is a win.
